### PR TITLE
_my_activityを表示するとき、言語ファイルの内容を反映するよう修正

### DIFF
--- a/app/views/my/blocks/_my_activity.html.erb
+++ b/app/views/my/blocks/_my_activity.html.erb
@@ -4,7 +4,7 @@
   events_by_day = events.group_by(&:event_date)
 %>
 
-<h3><%= l(:label_activity) %></h3>
+<h3><%= l(:my_activity) %></h3>
 
 <div id="activity">
 <% events_by_day.keys.sort.reverse.each do |day| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,6 @@
 en:
   priority_issues: "Priority issues"
-  my_activities: "My activities"
+  my_activity: "My activities"
   neglected_issues: "Neglected issues"
   new_issues: "Recently created issues"
   doing_issues: "Doing issues"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,6 @@
 ja:
   priority_issues: "優先チケット"
-  my_activities: "自分の活動"
+  my_activity: "自分の活動"
   neglected_issues: "放置チケット"
   new_issues: "新着チケット"
   doing_issues: "作業中チケット"


### PR DESCRIPTION
マイページにある「マイページパーツ」コンボボックス内に表示される、my_activity(自分の活動)の翻訳ファイルが反映されていないようでした。
修正してみましたので内容をご確認いただけますか？
githubを使うのも、pull requestも、Rubyも初めてなので、不手際があったら申し訳ありません。
