### PR TITLE
fixes 'show link larger, no priority ticket'

### DIFF
--- a/app/views/my/blocks/_priority_issues.html.erb
+++ b/app/views/my/blocks/_priority_issues.html.erb
@@ -1,4 +1,4 @@
-<h3><%= l(:priority_issues) %>
+<h3><%= l(:priority_issues) %></h3>
 
 <%
   open_issues = Issue.visible.open


### PR DESCRIPTION
優先チケットが何もない場合、以下のリンク表示が
「優先チケット」の項目表示と同じフォントサイズになっていたのを
修正した。

自分のすべてのチケット | すべてのチケット
