### PR TITLE
My activities block hasn't icon of issues.

### DIFF
--- a/app/views/my/blocks/_my_activity.html.erb
+++ b/app/views/my/blocks/_my_activity.html.erb
@@ -12,7 +12,7 @@
 <h4><%= format_activity_day(day) %></h4>
 <dl>
 <% events_by_day[day].sort {|x,y| y.event_datetime <=> x.event_datetime }.each do |e| -%>
-  <dt class="<%= e.event_type %>">
+  <dt class="<%= e.event_type %> icon icon-<%= e.event_type %>">
   <span class="time"><%= format_time(e.event_datetime, false) %></span>
   <%= content_tag('span', h(e.project), :class => 'project') %>
   <%= link_to format_activity_title(e.event_title), e.event_url %></dt>


### PR DESCRIPTION
**My activities** block hasn't icon of issues on Redmine 3.4.2 and trunk.
I expect to show icons like Activity page.
On Redmine 3.3.4 with your redmine-3.0 branch, it's no problem.
