### PR TITLE
Support SVG icon for settings introduced in Redmine 6.0

### DIFF
--- a/app/views/my/_my_page_blocks_issues.html.erb
+++ b/app/views/my/_my_page_blocks_issues.html.erb
@@ -1,6 +1,11 @@
 <%# The original of this file is 'app/views/my/blocks/_issues.erb' %>
 <div class="contextual">
-  <%= link_to_function l(:label_options), "$('##{block}-settings').toggle();", :class => 'icon-only icon-settings', :title => l(:label_options) %>
+  <%# If Redmine version is 6.0 or later, use the SVG icon introduced in Redmine 6.0 %>
+  <% if Gem::Version.new(Redmine::VERSION.to_s) >= Gem::Version.new('6.0.0') %>
+    <%= link_to_function sprite_icon('settings', l(:label_options)), "$('##{block}-settings').toggle();", :class => 'icon-only', :title => l(:label_options) %>
+  <% else %>
+    <%= link_to_function l(:label_options), "$('##{block}-settings').toggle();", :class => 'icon-only icon-settings', :title => l(:label_options) %>
+  <% end %>
 </div>
 
 <h3>


### PR DESCRIPTION
This pull request updates the settings button icon for blocks added by this plugin to use the SVG icons introduced in Redmine 6.0.  

For Redmine versions 5.1 and earlier, the plugin will continue to display the traditional PNG icons.  

Below are screenshots showing the results in the latest versions of Redmine's `master` and `5.1-stable` branches, as well as RedMica's `stable-3.1` branch:  

Redmine 6.0.2 (master branch):
![redmine-master](https://github.com/user-attachments/assets/0fbf0f10-6cb1-4a34-86b4-9a80f193a5f9)
![redmine-master-2](https://github.com/user-attachments/assets/38e93d1f-0ef0-4521-b0fc-38bbc21bc66f)
![redmine-master-3](https://github.com/user-attachments/assets/002f29e5-613b-450e-90e3-f79978f68382)


Redmine 5.1 (5.1-stable):
![redmine-5 1-stable](https://github.com/user-attachments/assets/83dd6ec7-1466-46a8-bb45-c0bde5e65c87)

RedMica 3.1 (based on Redmine 6.0):
![redmica-stable-3 1](https://github.com/user-attachments/assets/e8860721-cd62-4018-9003-1cd481b3a80d)

